### PR TITLE
Add missing slash "/" to admin router button on appBar.vue

### DIFF
--- a/packages/renderer/src/components/layout/appBar.vue
+++ b/packages/renderer/src/components/layout/appBar.vue
@@ -108,7 +108,7 @@
         </router-link>
         <router-link
           v-if="isAdmin"
-          to="Admin"
+          to="/Admin"
           class="text-decoration-none mx-2 text-subtitle-1 text-white"
           active-class="text-primary-lighten-1"
         >


### PR DESCRIPTION
>Fix the Admin button working from pages other than Home